### PR TITLE
MITO-116: make ism-multisig buildable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ serde = "1.0.162"
 serde_json = "1.0.96"
 serde-json-wasm = "0.5.1"
 thiserror = { version = "1.0.37" }
-secp256k1 = "0.27.0"
+k256 = { version = "0.13.1", features = ["ecdsa"] }
 
 cw-multi-test = "0.16.1"
 cosmwasm-schema = "1.1.9"

--- a/contracts/ism-multisig/Cargo.toml
+++ b/contracts/ism-multisig/Cargo.toml
@@ -30,7 +30,7 @@ schemars = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 cosmwasm-schema = { workspace = true }
-secp256k1 = { workspace = true }
+k256 = { workspace = true }
 hpl-interface = { workspace = true }
 
 [dev-dependencies]

--- a/contracts/ism-multisig/src/query.rs
+++ b/contracts/ism-multisig/src/query.rs
@@ -65,13 +65,12 @@ pub fn verify_message(
 
 #[cfg(test)]
 mod test {
+    use crate::state::{ValidatorSet, Validators, THRESHOLD, VALIDATORS};
     use cosmwasm_std::{testing::mock_dependencies, to_binary, Addr, Binary, HexBinary};
     use hpl_interface::{
         ism::{ISMType, VerifyResponse},
         types::{message::Message, metadata::MessageIdMultisigIsmMetadata},
     };
-
-    use crate::state::{ValidatorSet, Validators, THRESHOLD, VALIDATORS};
 
     use super::{get_module_type, verify_message};
 

--- a/contracts/ism-multisig/src/verify.rs
+++ b/contracts/ism-multisig/src/verify.rs
@@ -1,8 +1,8 @@
 use crate::error::ContractError;
 use bech32::ToBase32;
 use cosmwasm_std::Binary;
+use k256::ecdsa::VerifyingKey;
 use ripemd::{Digest, Ripemd160};
-use secp256k1::{self, PublicKey};
 use sha2::Sha256;
 
 pub fn sha256_digest(bz: impl AsRef<[u8]>) -> Result<[u8; 32], ContractError> {
@@ -40,8 +40,7 @@ pub fn pub_to_addr(pub_key: Binary, prefix: &str) -> Result<String, ContractErro
 }
 
 pub fn uncompress_pubkey(pub_key_binary: Binary) -> Result<Binary, ContractError> {
-    let pub_key =
-        PublicKey::from_slice(&pub_key_binary).map_err(|_| ContractError::InvalidPubKey {})?;
+    let pub_key = VerifyingKey::from_sec1_bytes(&pub_key_binary).unwrap();
 
-    Ok(pub_key.serialize_uncompressed().into())
+    Ok(pub_key.to_encoded_point(false).as_bytes().into())
 }


### PR DESCRIPTION
* closes MITO-116
* change verification library from `secpk2561` to `k256`