### PR TITLE
feat(script): initial config setup

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,138 @@
+networks:
+  - id: "localosmosis"
+    hrp: "osmo"
+    endpoint:
+      rpc: "http://localhost:26657"
+      rest: "http://localhost:1317"
+      grpc: "http://localhost:9090"
+    gas:
+      price: "0.025"
+      denom: "uosmo"
+    domain: 1304 # localosmosis -> ascii / decimal -> sum
+
+  - id: "localneutron"
+    hrp: "neutron"
+    endpoint:
+      rpc: "http://localhost:26657"
+      rest: "http://localhost:1317"
+      grpc: "http://localhost:9090"
+    gas:
+      price: "0.025"
+      denom: "untrn"
+    domain: 1302
+
+signer: deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+
+deploy:
+  ism:
+    # # hpl_ism_multisig with default validator setup (signer = validator, threshold = 1)
+    # - 5
+    # - 420
+    # - 421613
+
+    # # hpl_ism_multisig
+    # type: multisig
+    # owner: osmo1g3q542hpttdrj9aaczsq0tkl0uyfk7nkydklz6
+    # validators:
+    #   5:
+    #     addrs:
+    #       - 2F47b319809A58bBBFa8e706171762eFBF168A62
+    #     threshold: 1
+    #   420:
+    #     addrs:
+    #       - 2F47b319809A58bBBFa8e706171762eFBF168A62
+    #     threshold: 1
+    #   421613:
+    #     addrs:
+    #       - 2F47b319809A58bBBFa8e706171762eFBF168A62
+    #     threshold: 1
+
+    # # hpl_test_mock_ism
+    # type: "mock"
+
+    # # hpl_ism_aggregate
+    # type: "aggregate"
+    # owner: osmo1g3q542hpttdrj9aaczsq0tkl0uyfk7nkydklz6
+    # isms:
+    #   - type: "mock"
+    #   - type: "multisig"
+    #   ...
+
+    # # hpl_ism_routing
+    # type: "routing"
+    # owner: osmo1g3q542hpttdrj9aaczsq0tkl0uyfk7nkydklz6
+    # isms:
+    #   5:
+    #     type: "mock"
+    #   420:
+    #     type: "multisig"
+    #     ...
+    #   421613:
+    #     type: "aggregate"
+    #     ...
+
+  hooks:
+    default:
+      # same as required field.
+    required:
+      # # hpl_test_mock_hook
+      # type: "mock"
+
+      # # hpl_hook_fee
+      # type: "fee"
+      # owner: osmo1g3q542hpttdrj9aaczsq0tkl0uyfk7nkydklz6
+      # fee:
+      #   denom: uosmo
+      #   amount: 1
+
+      # # hpl_hook_merkle
+      # type: "merkle"
+
+      # # hpl_hook_pausable
+      # type: "pausable"
+      # owner: osmo1g3q542hpttdrj9aaczsq0tkl0uyfk7nkydklz6
+      # paused: false
+
+      # # hpl_igp + hpl_igp_oracle
+      # type: "igp"
+      # token: "uosmo" # or default to gas token (in this case, uosmo will be set)
+      # configs:
+      #   5:
+      #     exchange_rate: 1.0
+      #     gas_price: 40000
+      #   420:
+      #     exchange_rate: 1.4
+      #     gas_price: 10322
+      #   ...
+
+      # # hpl_hook_aggregate
+      # type: aggregate
+      # owner: osmo1g3q542hpttdrj9aaczsq0tkl0uyfk7nkydklz6
+      # hooks:
+      #   - type: merkle
+      #   - type: pausable
+      #     owner: osmo1g3q542hpttdrj9aaczsq0tkl0uyfk7nkydklz6
+      #     paused: false
+      #   - type: fee
+      #     owner: osmo1g3q542hpttdrj9aaczsq0tkl0uyfk7nkydklz6
+      #     fee:
+      #       denom: uosmo
+      #       amount: 1
+
+      # # hpl_hook_routing / hpl_hook_routing_custom / hpl_hook_routing_fallback
+      # type: "routing"
+      # owner: osmo1g3q542hpttdrj9aaczsq0tkl0uyfk7nkydklz6
+      # hooks:
+      #   5:
+      #     type: fee
+      #     owner: osmo1g3q542hpttdrj9aaczsq0tkl0uyfk7nkydklz6
+      #     fee:
+      #       denom: uosmo
+      #       amount: 1
+      #   420:
+      #     type: "mock"
+      # custom_hooks: # optional
+      #   5:
+      #     recipient: osmo1g3q542hpttdrj9aaczsq0tkl0uyfk7nkydklz6
+      #     hook: osmo1g3q542hpttdrj9aaczsq0tkl0uyfk7nkydklz6
+      # fallback_hook: osmo1g3q542hpttdrj9aaczsq0tkl0uyfk7nkydklz6 # optional

--- a/script/shared/config.ts
+++ b/script/shared/config.ts
@@ -1,0 +1,199 @@
+import yaml from "js-yaml";
+import { readFileSync } from "fs";
+import { SigningCosmWasmClient } from "@cosmjs/cosmwasm-stargate";
+import {
+  Comet38Client,
+  Tendermint34Client,
+  Tendermint37Client,
+  CometClient,
+} from "@cosmjs/tendermint-rpc";
+import {
+  DirectSecp256k1HdWallet,
+  DirectSecp256k1Wallet,
+} from "@cosmjs/proto-signing";
+import { GasPrice, SigningStargateClient } from "@cosmjs/stargate";
+import { Secp256k1, keccak256 } from "@cosmjs/crypto";
+
+export type IsmType =
+  | {
+      type: "multisig";
+      owner: string;
+      validators: {
+        [domain: number]: { addrs: string[]; threshold: number };
+      };
+    }
+  | {
+      type: "mock";
+    }
+  | {
+      type: "aggregate";
+      owner: string;
+      isms: Exclude<IsmType, number[]>[];
+    }
+  | {
+      type: "routing";
+      owner: string;
+      isms: { [domain: number]: Exclude<IsmType, number[]> };
+    }
+  | number[];
+
+export type FeeHookType = {
+  type: "fee";
+  owner: string;
+  fee: {
+    denom?: string;
+    amount: bigint;
+  };
+};
+
+export type IgpHookType = {
+  type: "igp";
+  owner: string;
+  token?: string;
+  configs: {
+    [domain: number]: {
+      exchange_rate: number;
+      gas_price: number;
+    };
+  };
+  default_gas_usage: number;
+};
+
+export type RoutingHookType = {
+  type: "routing";
+  owner: string;
+  hooks: { [domain: number]: HookType };
+};
+
+export type RoutingCustomHookType = {
+  type: "routing-custom";
+  owner: string;
+  hooks: { [domain: number]: HookType };
+  custom_hooks: {
+    [domain: number]: { recipient: string; hook: HookType };
+  };
+};
+
+export type RoutingFallbackHookType = {
+  type: "routing-fallback";
+  owner: string;
+  hooks: { [domain: number]: HookType };
+  fallback_hook: HookType;
+};
+
+export type HookType =
+  | FeeHookType
+  | {
+      type: "merkle";
+    }
+  | {
+      type: "mock";
+    }
+  | {
+      type: "pausable";
+      owner: string;
+      paused: boolean;
+    }
+  | IgpHookType
+  | { type: "aggregate"; owner: string; hooks: HookType[] }
+  | RoutingHookType
+  | RoutingCustomHookType
+  | RoutingFallbackHookType;
+
+export type Config = {
+  networks: {
+    id: string;
+    hrp: string;
+    endpoint: {
+      rpc: string;
+      rest: string;
+      grpc: string;
+    };
+    gas: {
+      price: string;
+      denom: string;
+    };
+    domain: number;
+    tm_version?: "34" | "37" | "38";
+  }[];
+
+  signer: string;
+
+  deploy: {
+    ism?: IsmType;
+    hooks?: {
+      default?: HookType;
+      required?: HookType;
+    };
+  };
+};
+
+export class Client {
+  wasm: SigningCosmWasmClient;
+  stargate: SigningStargateClient;
+  signer: string;
+  signer_addr: string;
+  signer_pubkey: string;
+}
+
+const path = process.env.CONFIG || `${process.cwd()}/config.yaml`;
+
+export const getNetwork = (networkId: string): Config["networks"][number] => {
+  const ret = config.networks.find((v) => v.id === networkId);
+  if (!ret)
+    throw new Error(`Network ${networkId} not found in the config file`);
+  return ret;
+};
+
+export const config = yaml.load(readFileSync(path, "utf-8")) as Config;
+
+export async function getSigningClient(
+  networkId: string,
+  { signer }: Config
+): Promise<Client> {
+  const { tm_version, hrp, gas, endpoint } = getNetwork(networkId);
+
+  const wallet =
+    signer.split(" ").length > 1
+      ? await DirectSecp256k1HdWallet.fromMnemonic(signer, { prefix: hrp })
+      : await DirectSecp256k1Wallet.fromKey(Buffer.from(signer, "hex"), hrp);
+
+  const [account] = await wallet.getAccounts();
+  const gasPrice = GasPrice.fromString(`${gas.price}${gas.denom}`);
+
+  let clientBase: CometClient;
+
+  switch (tm_version || "38") {
+    case "34":
+      clientBase = await Tendermint34Client.connect(endpoint.rpc);
+      break;
+    case "37":
+      clientBase = await Tendermint37Client.connect(endpoint.rpc);
+      break;
+    case "38":
+      clientBase = await Comet38Client.connect(endpoint.rpc);
+      break;
+  }
+
+  const wasm = await SigningCosmWasmClient.createWithSigner(
+    clientBase,
+    wallet,
+    { gasPrice }
+  );
+  const stargate = await SigningStargateClient.createWithSigner(
+    clientBase,
+    wallet,
+    { gasPrice }
+  );
+
+  const pubkey = Secp256k1.uncompressPubkey(account.pubkey);
+  const ethaddr = keccak256(pubkey.slice(1)).slice(-20);
+
+  return {
+    wasm,
+    stargate,
+    signer: account.address,
+    signer_addr: Buffer.from(ethaddr).toString("hex"),
+    signer_pubkey: Buffer.from(account.pubkey).toString("hex"),
+  };
+}

--- a/script/shared/constants.ts
+++ b/script/shared/constants.ts
@@ -1,0 +1,28 @@
+import path from "path";
+
+export const defaultTmpDir = path.join(process.cwd(), "./tmp");
+export const defaultContextPath = path.join(process.cwd(), "./context");
+export const defaultArtifactPath = path.join(process.cwd(), "./artifacts");
+
+export const contractNames = [
+  "hpl_mailbox",
+  "hpl_validator_announce",
+  "hpl_ism_aggregate",
+  "hpl_ism_multisig",
+  "hpl_ism_pausable",
+  "hpl_ism_routing",
+  "hpl_igp",
+  "hpl_hook_aggregate",
+  "hpl_hook_fee",
+  "hpl_hook_merkle",
+  "hpl_hook_pausable",
+  "hpl_hook_routing",
+  "hpl_hook_routing_custom",
+  "hpl_hook_routing_fallback",
+  "hpl_test_mock_hook",
+  "hpl_test_mock_ism",
+  "hpl_test_mock_msg_receiver",
+  "hpl_igp_oracle",
+  "hpl_warp_cw20",
+  "hpl_warp_native",
+];

--- a/script/shared/context.ts
+++ b/script/shared/context.ts
@@ -1,0 +1,93 @@
+import fs from "fs";
+import path from "path";
+
+import { ContractNames } from "./contract";
+import { defaultContextPath } from "./constants";
+
+type typed<T extends ContractNames> = { type: T; address: string };
+
+export type ContextIsm =
+  | (typed<"hpl_ism_aggregate"> & {
+      isms: ContextIsm[];
+    })
+  | typed<"hpl_ism_multisig">
+  | typed<"hpl_ism_pausable">
+  | (typed<"hpl_ism_routing"> & {
+      isms: Record<number, ContextIsm>;
+    })
+  | typed<"hpl_test_mock_ism">;
+
+export type ContextHook =
+  | (typed<"hpl_igp"> & { oracle: typed<"hpl_igp_oracle"> })
+  | (typed<"hpl_hook_aggregate"> & {
+      hooks: ContextHook[];
+    })
+  | typed<"hpl_hook_fee">
+  | typed<"hpl_hook_merkle">
+  | typed<"hpl_hook_pausable">
+  | (typed<"hpl_hook_routing"> & {
+      hooks: Record<number, ContextHook>;
+    })
+  | (typed<"hpl_hook_routing_custom"> & {
+      hooks: Record<number, Record<string | "default", ContextHook>>;
+    })
+  | (typed<"hpl_hook_routing_fallback"> & {
+      hooks: Record<number | "fallback", ContextHook>;
+    })
+  | typed<"hpl_test_mock_hook">;
+
+export type ContextDeployments = {
+  core?: {
+    mailbox?: typed<"hpl_mailbox">;
+    validator_announce?: typed<"hpl_validator_announce">;
+  };
+  isms?: ContextIsm;
+  hooks?: {
+    default?: ContextHook;
+    required?: ContextHook;
+  };
+  warp?: {
+    cw20?: typed<"hpl_warp_cw20">[];
+    native?: typed<"hpl_warp_native">[];
+  };
+  test?: {
+    msg_receiver?: typed<"hpl_test_mock_msg_receiver">;
+  };
+};
+
+export class Context {
+  artifacts: Record<ContractNames, number>;
+  deployments: ContextDeployments;
+
+  latestMigration?: string;
+}
+
+export function loadContext(
+  network: string,
+  { contextPath }: { contextPath: string } = {
+    contextPath: defaultContextPath,
+  }
+): Context {
+  try {
+    const fileName = path.join(contextPath, `${network}.json`);
+    const result = fs.readFileSync(fileName, "utf-8");
+    return JSON.parse(result.toString()) as Context;
+  } catch (err) {}
+
+  return {
+    artifacts: {},
+    deployments: {},
+  };
+}
+
+export function saveContext(
+  network: string,
+  context: Context,
+  { contextPath }: { contextPath: string } = {
+    contextPath: defaultContextPath,
+  }
+) {
+  fs.mkdirSync(contextPath, { recursive: true });
+  const fileName = path.join(contextPath, `${network}.json`);
+  fs.writeFileSync(fileName, JSON.stringify(context, null, 2));
+}

--- a/script/shared/contract.ts
+++ b/script/shared/contract.ts
@@ -1,0 +1,86 @@
+import { contractNames } from "./constants";
+import { Context } from "./context";
+import { waitTx } from "./utils";
+import { Client } from "./config";
+import { IndexedTx } from "@cosmjs/stargate";
+
+export type ContractNames = (typeof contractNames)[number];
+
+export async function deployContract<T extends ContractNames>(
+  ctx: Context,
+  { wasm, stargate, signer }: Client,
+  contractName: T,
+  initMsg: any
+): Promise<{ type: T; address: string }> {
+  console.log(`Deploying ${contractName}`);
+
+  const codeId = ctx.artifacts[contractName];
+  const res = await wasm.instantiate(
+    signer,
+    codeId,
+    initMsg,
+    `cw-hpl: ${contractName}`,
+    "auto"
+  );
+  const receipt = await waitTx(res.transactionHash, stargate);
+  if (receipt.code > 0) {
+    throw new Error(`Error deploying ${contractName}: ${receipt.hash}`);
+  }
+
+  console.log(`Deployed ${contractName} at ${res.contractAddress}`);
+  return { type: contractName, address: res.contractAddress };
+}
+
+export async function executeContract(
+  { wasm, stargate, signer }: Client,
+  deployment: { type: ContractNames; address: string },
+  msg: any,
+  funds: { amount: string; denom: string }[] = []
+): Promise<IndexedTx> {
+  console.log(`Executing ${deployment.type}'s ${Object.keys(msg)[0]}`);
+
+  const res = await wasm.execute(
+    signer,
+    deployment.address,
+    msg,
+    "auto",
+    undefined,
+    funds
+  );
+  const receipt = await waitTx(res.transactionHash, stargate);
+  if (receipt.code > 0) {
+    throw new Error(`Error executing ${deployment.type}: ${receipt.hash}`);
+  }
+
+  return receipt;
+}
+
+export async function executeMultiMsg(
+  { wasm, stargate, signer }: Client,
+  msgs: { contract: { type: ContractNames; address: string }; msg: any }[]
+): Promise<IndexedTx> {
+  const long = msgs
+    .map((v) => v.contract.type.length)
+    .reduce((max, v) => Math.max(v, max), 0);
+
+  console.log("Executing multiple messages.");
+  for (const msg of msgs) {
+    console.log(
+      `- ${msg.contract.type.padEnd(long, " ")}: ${Object.keys(msg.msg)[0]}`
+    );
+  }
+
+  const res = await wasm.executeMultiple(
+    signer,
+    msgs.map((v) => ({
+      contractAddress: v.contract.address,
+      msg: v.msg,
+    })),
+    "auto"
+  );
+  const receipt = await waitTx(res.transactionHash, stargate);
+  if (receipt.code > 0) {
+    throw new Error(`Error executing multiple contracts: ${receipt.hash}`);
+  }
+  return receipt;
+}

--- a/script/shared/ioc.ts
+++ b/script/shared/ioc.ts
@@ -1,0 +1,17 @@
+import { Container } from "inversify";
+
+import { Context } from "./context";
+import { Client } from "./config";
+
+export const CONTAINER = new Container({
+  autoBindInjectable: true,
+  defaultScope: "Singleton",
+});
+
+// referenced by tsoa
+export const iocContainer = CONTAINER;
+
+export class Dependencies {
+  ctx: Context;
+  client: Client;
+}

--- a/script/shared/utils.ts
+++ b/script/shared/utils.ts
@@ -1,0 +1,78 @@
+import * as readline from "readline";
+import * as fs from "fs";
+import { finished } from "stream/promises";
+import { Readable } from "stream";
+import { createHash } from "crypto";
+import { IndexedTx, StargateClient } from "@cosmjs/stargate";
+import { fromBech32 } from "@cosmjs/encoding";
+
+export const sleep = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export function askQuestion(query: string) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) =>
+    rl.question(`${query} [Y/n] `, (ans) => {
+      rl.close();
+      resolve(ans.toLowerCase() == "y" ? true : false);
+    })
+  );
+}
+
+export const addPad = (v: string): string => {
+  const s = v.startsWith("0x") ? v.slice(2) : v;
+  return s.padStart(64, "0");
+};
+
+export const withLink = (text: string, url: string) =>
+  `${text} (\u200B${url}\u200B)`;
+
+export const extractByte32AddrFromBech32 = (addr: string): string => {
+  const { data } = fromBech32(addr);
+  const hexed = Buffer.from(data).toString("hex");
+  return hexed.length === 64 ? hexed : addPad(hexed);
+};
+
+export const downloadFile = async (url: string, dest: string) => {
+  const res = await fetch(url);
+  const fileStream = fs.createWriteStream(dest, { flags: "wx" });
+  await finished(Readable.fromWeb(res.body!).pipe(fileStream));
+};
+
+export const generateSha256 = (file: string): Promise<[string, string]> =>
+  new Promise((resolve, reject) => {
+    const stream = fs.createReadStream(file);
+    const hash = createHash("sha256");
+
+    stream.on("error", (err) => reject(err));
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve([file, hash.digest("hex")]));
+  });
+
+export const waitTx = async (
+  txHash: string,
+  client: StargateClient,
+  { waitMs, tryCount }: { waitMs: number; tryCount: number } = {
+    waitMs: 1000,
+    tryCount: 30,
+  }
+): Promise<IndexedTx> => {
+  let found: IndexedTx | null = null;
+  let count = 0;
+  while (!found) {
+    found = await client.getTx(txHash);
+    count++;
+    await sleep(waitMs); // default to 1s
+
+    if (count > tryCount) {
+      throw new Error(
+        `max try count exceeded. count: ${tryCount}, waitMs: ${waitMs}`
+      );
+    }
+  }
+  return found;
+};


### PR DESCRIPTION
* config
    * Configuration manager. reads `.yaml` config file and parses into `Config` type.
    * Includes `signingClient` maker from config
    * Also has config about contract deployment like `ISMType` or `HookType`
* context
    * Has type definition about Context.
    * Context is aggregated data type about all of contract deployment cycle.
        * CodeIds by contract name
        * Deployed contract addresses & other metadata
* constants
    * Contains list of contract names
    * It should be same as artifact file name like `hpl_mailbox.wasm` -> `hpl_mailbox`
* contract
    * Wrapped helper functions about `deploy`, `execute`, `executeMany`
    * And type definition of `constants.contractNames`
* ioc
    * Definition of `inversify` container.
    * We utilizes it by injecting common dependencies
* utils