### PR TITLE
Add functionality for deploying and modifying deployments

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -44,7 +44,7 @@ evm_networks:
       symbol: 'ETH'
       decimals: 18
     mailbox_address: "0x123..."
-    multisig_ism_factory_addres: "0x123..."
+    multisig_ism_factory_address: "0x123..."
 
 
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -32,6 +32,22 @@ networks:
       denom: 'untrn'
     domain: 1302
 
+# Networks that already have hyperlane deployments
+# but might require new warp route connections
+evm_networks:
+  - name: 'mantasepolia'
+    chain_id: 3441006
+    rpc_endpoint: "http://localhost:8545"
+    network: 'sepolia'
+    nativeCurrency:
+      name: 'Sepolia Ether'
+      symbol: 'ETH'
+      decimals: 18
+    mailbox_address: "0x123..."
+    multisig_ism_factory_addres: "0x123..."
+
+
+
 signer: deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
 
 deploy:

--- a/example/src/recipient.ts
+++ b/example/src/recipient.ts
@@ -8,11 +8,17 @@ import { HYP_MULTSIG_ISM_FACTORY } from './constants';
 import { CONTAINER, Dependencies } from './ioc';
 import { expectNextContractAddr, logTx } from './utils';
 
-export const recipientCmd = new Command('deploy-test-recipient').action(
+export const recipientCmd = new Command('deploy-test-recipient')
+  .option('--validator-address <validator-address>', 'validator address to use')
+  .action(
   deployTestRecipient,
 );
 
-async function deployTestRecipient() {
+type DeployTestRecipientArgs = {
+  validatorAddress?: `0x{string}`
+}
+
+async function deployTestRecipient({validatorAddress}: DeployTestRecipientArgs) {
   const {
     account,
     provider: { query, exec },
@@ -37,7 +43,7 @@ async function deployTestRecipient() {
     abi: StaticMessageIdMultisigIsmFactory__factory.abi,
     address: HYP_MULTSIG_ISM_FACTORY,
     functionName: 'getAddress',
-    args: [[account.address], 1],
+    args: [[validatorAddress ? validatorAddress : account.address], 1],
   });
   console.log(`Deploying multisigIsm at "${multisigIsmAddr.green}"...`);
 
@@ -46,7 +52,7 @@ async function deployTestRecipient() {
       abi: StaticMessageIdMultisigIsmFactory__factory.abi,
       address: HYP_MULTSIG_ISM_FACTORY,
       functionName: 'deploy',
-      args: [[account.address], 1],
+      args: [[validatorAddress ? validatorAddress : account.address], 1],
     });
     logTx('Deploy multisig ism', tx);
     await query.waitForTransactionReceipt({ hash: tx });

--- a/example/src/recipient.ts
+++ b/example/src/recipient.ts
@@ -43,7 +43,7 @@ async function deployTestRecipient({validatorAddress}: DeployTestRecipientArgs) 
     abi: StaticMessageIdMultisigIsmFactory__factory.abi,
     address: HYP_MULTSIG_ISM_FACTORY,
     functionName: 'getAddress',
-    args: [[validatorAddress ? validatorAddress : account.address], 1],
+    args: [[validatorAddress || account.address], 1],
   });
   console.log(`Deploying multisigIsm at "${multisigIsmAddr.green}"...`);
 
@@ -52,7 +52,7 @@ async function deployTestRecipient({validatorAddress}: DeployTestRecipientArgs) 
       abi: StaticMessageIdMultisigIsmFactory__factory.abi,
       address: HYP_MULTSIG_ISM_FACTORY,
       functionName: 'deploy',
-      args: [[validatorAddress ? validatorAddress : account.address], 1],
+      args: [[validatorAddress || account.address], 1],
     });
     logTx('Deploy multisig ism', tx);
     await query.waitForTransactionReceipt({ hash: tx });

--- a/example/src/warp.ts
+++ b/example/src/warp.ts
@@ -1,5 +1,5 @@
 import { HypERC20__factory } from '@hyperlane-xyz/core';
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { isAddress } from 'viem';
 
 import { HYP_MAILBOX } from './constants';
@@ -12,7 +12,10 @@ import {
 
 const warpCmd = new Command('warp');
 
-warpCmd.command('deploy').action(deployWarpRoute);
+warpCmd.command('deploy')
+  .option('--ism-address <ism-address>', 'ISM to set on test recipient')
+  .action(deployWarpRoute);
+
 warpCmd
   .command('link')
   .argument('<warp>', 'address of warp route')
@@ -29,7 +32,7 @@ warpCmd
 
 export { warpCmd };
 
-async function deployWarpRoute() {
+async function deployWarpRoute({ismAddress}) {
   const {
     account,
     provider: { query, exec },
@@ -60,6 +63,18 @@ async function deployWarpRoute() {
     logTx('Initialize HypERC20Osmo', tx);
     await query.waitForTransactionReceipt({ hash: tx });
   }
+
+  if (ismAddress !== undefined) {
+    const tx = await exec.writeContract({
+      abi: HypERC20__factory.abi,
+      address: hypErc20OsmoAddr,
+      functionName: 'setInterchainSecurityModule',
+      args: [ismAddress],
+    });
+    logTx('Set ism for warp route', tx);
+    await query.waitForTransactionReceipt({ hash: tx });
+  }
+
 
   console.log('== Done! ==');
 

--- a/example/src/warp.ts
+++ b/example/src/warp.ts
@@ -14,6 +14,8 @@ const warpCmd = new Command('warp');
 
 warpCmd.command('deploy')
   .option('--ism-address <ism-address>', 'ISM to set on test recipient')
+  .option('--contract-name <contract-name>', 'Warp contract name e.g. Hyperlane Bridged TIA')
+  .option('--asset-name <asset-name>', 'Warp route asset name e.g. TIA')
   .action(deployWarpRoute);
 
 warpCmd
@@ -33,10 +35,12 @@ warpCmd
 export { warpCmd };
 
 type DeployWarpRouteArgs = {
-  ismAddress: `0x${string}`
+  ismAddress?: `0x${string}`,
+  contractName?: string,
+  assetName?: string,
 };
 
-async function deployWarpRoute({ismAddress}: DeployWarpRouteArgs) {
+async function deployWarpRoute({ismAddress, contractName, assetName}: DeployWarpRouteArgs) {
   const {
     account,
     provider: { query, exec },
@@ -62,7 +66,7 @@ async function deployWarpRoute({ismAddress}: DeployWarpRouteArgs) {
       abi: HypERC20__factory.abi,
       address: hypErc20OsmoAddr,
       functionName: 'initialize',
-      args: [0n, 'Hyperlane Bridged Osmosis', 'OSMO'],
+      args: [0n, contractName ? contractName : 'Hyperlane Bridged OSMO', assetName ? assetName : 'OSMO'],
     });
     logTx('Initialize HypERC20Osmo', tx);
     await query.waitForTransactionReceipt({ hash: tx });

--- a/example/src/warp.ts
+++ b/example/src/warp.ts
@@ -1,5 +1,5 @@
 import { HypERC20__factory } from '@hyperlane-xyz/core';
-import { Command, Option } from 'commander';
+import { Command} from 'commander';
 import { isAddress } from 'viem';
 
 import { HYP_MAILBOX } from './constants';
@@ -32,7 +32,11 @@ warpCmd
 
 export { warpCmd };
 
-async function deployWarpRoute({ismAddress}) {
+type DeployWarpRouteArgs = {
+  ismAddress: `0x${string}`
+};
+
+async function deployWarpRoute({ismAddress}: DeployWarpRouteArgs) {
   const {
     account,
     provider: { query, exec },

--- a/example/src/warp.ts
+++ b/example/src/warp.ts
@@ -1,8 +1,11 @@
-import { HypERC20__factory } from '@hyperlane-xyz/core';
-import { Command} from 'commander';
+import { 
+  HypERC20__factory, 
+  StaticMessageIdMultisigIsmFactory__factory,
+} from '@hyperlane-xyz/core';
+import { Command, Option} from 'commander';
 import { isAddress } from 'viem';
 
-import { HYP_MAILBOX } from './constants';
+import { HYP_MAILBOX, HYP_MULTSIG_ISM_FACTORY } from './constants';
 import { CONTAINER, Dependencies } from './ioc';
 import {
   expectNextContractAddr,
@@ -13,9 +16,29 @@ import {
 const warpCmd = new Command('warp');
 
 warpCmd.command('deploy')
-  .option('--ism-address <ism-address>', 'ISM to set on test recipient')
-  .option('--contract-name <contract-name>', 'Warp contract name e.g. Hyperlane Bridged TIA')
-  .option('--asset-name <asset-name>', 'Warp route asset name e.g. TIA')
+  .option(
+    '--contract-name <contract-name>', 
+    'Warp contract name e.g. Hyperlane Bridged TIA',
+    'Hyperlane Bridged Osmo'
+  )
+  .option(
+    '--asset-name <asset-name>', 
+    'Warp route asset name e.g. TIA',
+    'TIA'
+  )
+  .option(
+    '--create-new-ism', 
+    'Option to create a new ISM for the the warp route',
+    false
+  )
+  .option(
+    '--warp-ism-address <warp-ism-address>', 
+    'ISM to set on the warp route recipient'
+  )
+  .option(
+    '--ism-validator-address <ism-validator-address>', 
+    'Validator address on the ism',
+  )
   .action(deployWarpRoute);
 
 warpCmd
@@ -35,21 +58,32 @@ warpCmd
 export { warpCmd };
 
 type DeployWarpRouteArgs = {
-  ismAddress?: `0x${string}`,
-  contractName?: string,
-  assetName?: string,
+  contractName: string,
+  assetName: string,
+  createNewIsm?: boolean,
+  warpIsmAddress?: `0x${string}`,
+  ismValidatorAddress?: `0x${string}`,
 };
 
-async function deployWarpRoute({ismAddress, contractName, assetName}: DeployWarpRouteArgs) {
+async function deployWarpRoute({
+  contractName,
+  assetName,
+  createNewIsm,
+  warpIsmAddress,
+  ismValidatorAddress,
+}: DeployWarpRouteArgs) {
   const {
     account,
     provider: { query, exec },
   } = CONTAINER.get(Dependencies);
 
-  // deploy hyp erc20 (implementation)
+  if (createNewIsm && warpIsmAddress !== undefined) {
+    throw new Error("invalid options: cannot create a new ISM and pass a custom ISM address at the same time")
+  }
 
-  const hypErc20OsmoAddr = await expectNextContractAddr(query, account);
-  console.log(`Deploying HypERC20 at "${hypErc20OsmoAddr.green}"...`);
+  // deploy hyp erc20 (implementation)
+  const hypErc20Addr = await expectNextContractAddr(query, account);
+  console.log(`Deploying HypERC20 at "${hypErc20Addr.green}"...`);
 
   {
     const tx = await exec.deployContract({
@@ -57,37 +91,65 @@ async function deployWarpRoute({ismAddress, contractName, assetName}: DeployWarp
       bytecode: HypERC20__factory.bytecode,
       args: [6, HYP_MAILBOX],
     });
-    logTx('Deploying HypERC20Osmo', tx);
+    logTx('Deploying HypERC20', tx);
     await query.waitForTransactionReceipt({ hash: tx });
   }
 
   {
     const tx = await exec.writeContract({
       abi: HypERC20__factory.abi,
-      address: hypErc20OsmoAddr,
+      address: hypErc20Addr,
       functionName: 'initialize',
       args: [0n, contractName ? contractName : 'Hyperlane Bridged OSMO', assetName ? assetName : 'OSMO'],
     });
-    logTx('Initialize HypERC20Osmo', tx);
+    logTx('Initialize HypERC20', tx);
     await query.waitForTransactionReceipt({ hash: tx });
   }
 
-  if (ismAddress !== undefined) {
+  // If the option was specifed to create a new ISM, deploy the multisig ISM contract
+  if (createNewIsm) {
+    ismValidatorAddress = ismValidatorAddress ? ismValidatorAddress : account.address
+
+    const multisigIsmAddr = await query.readContract({
+      abi: StaticMessageIdMultisigIsmFactory__factory.abi,
+      address: HYP_MULTSIG_ISM_FACTORY,
+      functionName: 'getAddress',
+      args: [[ismValidatorAddress], 1],
+    });
+    console.log(`Deploying multisigIsm at "${multisigIsmAddr.green}"...`);
+  
+    {
+      const tx = await exec.writeContract({
+        abi: StaticMessageIdMultisigIsmFactory__factory.abi,
+        address: HYP_MULTSIG_ISM_FACTORY,
+        functionName: 'deploy',
+        args: [[ismValidatorAddress], 1],
+      });
+      logTx('Deploy multisig ism', tx);
+      await query.waitForTransactionReceipt({ hash: tx });
+    }
+
+    warpIsmAddress = multisigIsmAddr
+  }
+  
+  // If a custom ISM address was specified or if a new ISM was created,
+  // register that address in the warp contract
+  // Otherwise, the default ISM will be used
+  if (warpIsmAddress !== undefined) {
     const tx = await exec.writeContract({
       abi: HypERC20__factory.abi,
-      address: hypErc20OsmoAddr,
+      address: hypErc20Addr,
       functionName: 'setInterchainSecurityModule',
-      args: [ismAddress],
+      args: [warpIsmAddress],
     });
     logTx('Set ism for warp route', tx);
     await query.waitForTransactionReceipt({ hash: tx });
   }
 
-
   console.log('== Done! ==');
 
   console.log({
-    hypErc20Osmo: hypErc20OsmoAddr,
+    hypErc20: hypErc20Addr,
   });
 }
 

--- a/script/commands/evm.ts
+++ b/script/commands/evm.ts
@@ -26,7 +26,7 @@ evmCmd.command('deploy-warp')
       '--evm-network-name <evmNetworkName>',
       'specify the EVM network name',
     )
-    .choices(config.evm_networks.map((v) => v.name))
+    .choices(config.evm_networks ? config.evm_networks.map((v) => v.name) : [])
     .makeOptionMandatory()
   )
   .option(

--- a/script/commands/evm.ts
+++ b/script/commands/evm.ts
@@ -20,6 +20,26 @@ import {
 
 const evmCmd = new Command('evm')
 
+evmCmd.command('deploy-ism')
+  .addOption(
+    new Option(
+      '--evm-network-name <evmNetworkName>',
+      'specify the EVM network name',
+    )
+    .choices(config.evm_networks ? config.evm_networks.map((v) => v.name) : [])
+    .makeOptionMandatory()
+  )
+  .option(
+    '--validator-addresses <validator-addresses>', 
+    'Comma separated list of validator address on the ism',
+  )
+  .option(
+    '--threshold <threshold>', 
+    'Threshold for the number of validators in the ISM',
+    "1",
+  )
+  .action(deployIsm);
+
 evmCmd.command('deploy-warp')
   .addOption(
     new Option(
@@ -40,45 +60,96 @@ evmCmd.command('deploy-warp')
     'TIA'
   )
   .option(
-    '--create-new-ism', 
-    'Option to create a new ISM for the the warp route',
-    false
-  )
-  .option(
     '--warp-ism-address <warp-ism-address>', 
     'ISM to set on the warp route recipient'
-  )
-  .option(
-    '--ism-validator-addresses <ism-validator-addresses>', 
-    'Comma separated list of validator address on the ism',
-  )
-  .option(
-    '--ism-threshold <ism-threshold>', 
-    'Threshold for the number of validators in the ISM',
-    "1",
   )
   .action(deployWarpRoute);
 
 export { evmCmd };
 
+type DeployIsmArgs = {
+  evmNetworkName: string,
+  validatorAddresses?: `0x${string}`,
+  threshold?: number,
+};
+
+async function deployIsm({
+  evmNetworkName,
+  validatorAddresses,
+  threshold,
+}: DeployIsmArgs) {
+  const { signer } = config;
+  const evmNetwork = getEvmNetwork(evmNetworkName)
+  
+  const account: Account =
+    signer.split(' ').length > 1
+      ? mnemonicToAccount(signer)
+      : privateKeyToAccount(`0x${signer}` as Hex);
+
+  const chain: Chain = {
+    id: evmNetwork.chain_id,
+    network: evmNetwork.network,
+    name: evmNetwork.name,
+    nativeCurrency: evmNetwork.native_currency,
+    rpcUrls: {
+      default: {
+        http: [evmNetwork.rpc_endpoint],
+      },
+      public: {
+        http: [evmNetwork.rpc_endpoint],
+      },
+    },
+  }
+
+  const query = createPublicClient({
+    chain: chain,
+    transport: http(evmNetwork.rpc_endpoint),
+  })
+
+  const exec = createWalletClient({
+    chain: chain,
+    account,
+    transport: http(evmNetwork.rpc_endpoint),
+  });
+
+  const validatorAddressesString = validatorAddresses ? validatorAddresses : account.address
+  const validatorAddressesList = validatorAddressesString.split(",").map(address => address as `0x${string}`)
+
+  const multisigIsmAddr = await query.readContract({
+    abi: StaticMessageIdMultisigIsmFactory__factory.abi,
+    address: evmNetwork.multisig_ism_factory_address,
+    functionName: 'getAddress',
+    args: [validatorAddressesList, Number(threshold)],
+  });
+  console.log(`Multisig ISM Address to be deployed at: ${multisigIsmAddr.green}`);
+
+  {
+    const tx = await exec.writeContract({
+      abi: StaticMessageIdMultisigIsmFactory__factory.abi,
+      address: evmNetwork.multisig_ism_factory_address,
+      functionName: 'deploy',
+      args: [validatorAddressesList, Number(threshold)],
+    });
+    logTx('Deploying multisig ISM', tx);
+    await query.waitForTransactionReceipt({ hash: tx });
+  }
+
+  console.log(`Multisig ISM Address: ${multisigIsmAddr.blue}`);
+}
+
+
 type DeployWarpRouteArgs = {
   evmNetworkName: string,
   contractName: string,
   assetName: string,
-  createNewIsm?: boolean,
   warpIsmAddress?: `0x${string}`,
-  ismValidatorAddresses?: `0x${string}`,
-  ismThreshold?: number,
 };
 
 async function deployWarpRoute({
   evmNetworkName,
   contractName,
   assetName,
-  createNewIsm,
   warpIsmAddress,
-  ismValidatorAddresses,
-  ismThreshold,
 }: DeployWarpRouteArgs) {
   const { signer } = config;
   const evmNetwork = getEvmNetwork(evmNetworkName)
@@ -114,10 +185,6 @@ async function deployWarpRoute({
     transport: http(evmNetwork.rpc_endpoint),
   });
 
-  if (createNewIsm && warpIsmAddress !== undefined) {
-    throw new Error("invalid options: cannot create a new ISM and pass a custom ISM address at the same time")
-  }
-
   // deploy hyp erc20 (implementation)
   const hypErc20Addr = await expectNextContractAddr(query, account);
   console.log(`Deploying HypERC20 at "${hypErc20Addr.green}"...`);
@@ -142,36 +209,8 @@ async function deployWarpRoute({
     logTx('Initialize HypERC20', tx);
     await query.waitForTransactionReceipt({ hash: tx });
   }
-
-  // If the option was specifed to create a new ISM, deploy the multisig ISM contract
-  if (createNewIsm) {
-    const ismValidatorAddressString = ismValidatorAddresses ? ismValidatorAddresses : account.address
-    const ismValidatorAddressesList = ismValidatorAddressString.split(",").map(address => address as `0x${string}`)
-
-    const multisigIsmAddr = await query.readContract({
-      abi: StaticMessageIdMultisigIsmFactory__factory.abi,
-      address: evmNetwork.multisig_ism_factory_address,
-      functionName: 'getAddress',
-      args: [ismValidatorAddressesList, Number(ismThreshold)],
-    });
-    console.log(`\nDeploying multisigIsm at "${multisigIsmAddr.green}"...`);
   
-    {
-      const tx = await exec.writeContract({
-        abi: StaticMessageIdMultisigIsmFactory__factory.abi,
-        address: evmNetwork.multisig_ism_factory_address,
-        functionName: 'deploy',
-        args: [ismValidatorAddressesList, Number(ismThreshold)],
-      });
-      logTx('Deploy multisig ism', tx);
-      await query.waitForTransactionReceipt({ hash: tx });
-    }
-
-    warpIsmAddress = multisigIsmAddr
-  }
-  
-  // If a custom ISM address was specified or if a new ISM was created,
-  // register that address in the warp contract
+  // If a custom ISM address was specified, register that address in the warp contract
   // Otherwise, the default ISM will be used
   if (warpIsmAddress !== undefined) {
     const tx = await exec.writeContract({
@@ -185,7 +224,4 @@ async function deployWarpRoute({
   }
   
   console.log(`\nWarp ERC20: ${hypErc20Addr.blue}`);
-  if (warpIsmAddress !== undefined) {
-    console.log(`ISM Address: ${warpIsmAddress.blue}`);
-  }
 }

--- a/script/commands/evm.ts
+++ b/script/commands/evm.ts
@@ -1,191 +1,191 @@
 import { 
-    HypERC20__factory, 
-    StaticMessageIdMultisigIsmFactory__factory,
-  } from '@hyperlane-xyz/core';
-  import { Command, Option } from 'commander';
-  import {
-    Account,
-    Chain,
-    Hex,
-    createPublicClient,
-    createWalletClient,
-    http,
-  } from 'viem';
-  import { mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
-  import { config, getEvmNetwork } from '../shared/config';
-  import {
-    expectNextContractAddr,
-    logTx,
-  } from '../../example/src/utils';
-  
-  const evmCmd = new Command('evm')
-  
-  evmCmd.command('deploy-warp')
-    .addOption(
-      new Option(
-        '--evm-network-name <evmNetworkName>',
-        'specify the EVM network name',
-      )
-      .choices(config.evm_networks.map((v) => v.name))
-      .makeOptionMandatory()
-    )
-    .option(
-      '--contract-name <contract-name>', 
-      'Warp contract name e.g. Hyperlane Bridged TIA',
-      'Hyperlane Bridged Osmo'
-    )
-    .option(
-      '--asset-name <asset-name>', 
-      'Warp route asset name e.g. TIA',
-      'TIA'
-    )
-    .option(
-      '--create-new-ism', 
-      'Option to create a new ISM for the the warp route',
-      false
-    )
-    .option(
-      '--warp-ism-address <warp-ism-address>', 
-      'ISM to set on the warp route recipient'
-    )
-    .option(
-      '--ism-validator-address <ism-validator-address>', 
-      'Validator address on the ism',
-    )
-    .option(
-      '--ism-threshold <ism-threshold>', 
-      'Threshold for the number of validators in the ISM',
-      "1",
-    )
-    .action(deployWarpRoute);
-  
-  export { evmCmd };
-  
-  type DeployWarpRouteArgs = {
-    evmNetworkName: string,
-    contractName: string,
-    assetName: string,
-    createNewIsm?: boolean,
-    warpIsmAddress?: `0x${string}`,
-    ismValidatorAddress?: `0x${string}`,
-    ismThreshold?: number,
-  };
-  
-  async function deployWarpRoute({
-    evmNetworkName,
-    contractName,
-    assetName,
-    createNewIsm,
-    warpIsmAddress,
-    ismValidatorAddress,
-    ismThreshold,
-  }: DeployWarpRouteArgs) {
-    const { signer } = config;
-    const evmNetwork = getEvmNetwork(evmNetworkName)
-    
-    const account: Account =
-      signer.split(' ').length > 1
-        ? mnemonicToAccount(signer)
-        : privateKeyToAccount(`0x${signer}` as Hex);
+  HypERC20__factory, 
+  StaticMessageIdMultisigIsmFactory__factory,
+} from '@hyperlane-xyz/core';
+import { Command, Option } from 'commander';
+import {
+  Account,
+  Chain,
+  Hex,
+  createPublicClient,
+  createWalletClient,
+  http,
+} from 'viem';
+import { mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
+import { config, getEvmNetwork } from '../shared/config';
+import {
+  expectNextContractAddr,
+  logTx,
+} from '../../example/src/utils';
 
-    const chain: Chain = {
-      id: evmNetwork.chain_id,
-      network: evmNetwork.network,
-      name: evmNetwork.name,
-      nativeCurrency: evmNetwork.native_currency,
-      rpcUrls: {
-        default: {
-          http: [evmNetwork.rpc_endpoint],
-        },
-        public: {
-          http: [evmNetwork.rpc_endpoint],
-        },
+const evmCmd = new Command('evm')
+
+evmCmd.command('deploy-warp')
+  .addOption(
+    new Option(
+      '--evm-network-name <evmNetworkName>',
+      'specify the EVM network name',
+    )
+    .choices(config.evm_networks.map((v) => v.name))
+    .makeOptionMandatory()
+  )
+  .option(
+    '--contract-name <contract-name>', 
+    'Warp contract name e.g. Hyperlane Bridged TIA',
+    'Hyperlane Bridged Osmo'
+  )
+  .option(
+    '--asset-name <asset-name>', 
+    'Warp route asset name e.g. TIA',
+    'TIA'
+  )
+  .option(
+    '--create-new-ism', 
+    'Option to create a new ISM for the the warp route',
+    false
+  )
+  .option(
+    '--warp-ism-address <warp-ism-address>', 
+    'ISM to set on the warp route recipient'
+  )
+  .option(
+    '--ism-validator-addresses <ism-validator-addresses>', 
+    'Comma separated list of validator address on the ism',
+  )
+  .option(
+    '--ism-threshold <ism-threshold>', 
+    'Threshold for the number of validators in the ISM',
+    "1",
+  )
+  .action(deployWarpRoute);
+
+export { evmCmd };
+
+type DeployWarpRouteArgs = {
+  evmNetworkName: string,
+  contractName: string,
+  assetName: string,
+  createNewIsm?: boolean,
+  warpIsmAddress?: `0x${string}`,
+  ismValidatorAddresses?: `0x${string}`,
+  ismThreshold?: number,
+};
+
+async function deployWarpRoute({
+  evmNetworkName,
+  contractName,
+  assetName,
+  createNewIsm,
+  warpIsmAddress,
+  ismValidatorAddresses,
+  ismThreshold,
+}: DeployWarpRouteArgs) {
+  const { signer } = config;
+  const evmNetwork = getEvmNetwork(evmNetworkName)
+  
+  const account: Account =
+    signer.split(' ').length > 1
+      ? mnemonicToAccount(signer)
+      : privateKeyToAccount(`0x${signer}` as Hex);
+
+  const chain: Chain = {
+    id: evmNetwork.chain_id,
+    network: evmNetwork.network,
+    name: evmNetwork.name,
+    nativeCurrency: evmNetwork.native_currency,
+    rpcUrls: {
+      default: {
+        http: [evmNetwork.rpc_endpoint],
       },
-    }
+      public: {
+        http: [evmNetwork.rpc_endpoint],
+      },
+    },
+  }
 
-    const query = createPublicClient({
-      chain: chain,
-      transport: http(evmNetwork.rpc_endpoint),
-    })
+  const query = createPublicClient({
+    chain: chain,
+    transport: http(evmNetwork.rpc_endpoint),
+  })
 
-    const exec = createWalletClient({
-      chain: chain,
-      account,
-      transport: http(evmNetwork.rpc_endpoint),
+  const exec = createWalletClient({
+    chain: chain,
+    account,
+    transport: http(evmNetwork.rpc_endpoint),
+  });
+
+  if (createNewIsm && warpIsmAddress !== undefined) {
+    throw new Error("invalid options: cannot create a new ISM and pass a custom ISM address at the same time")
+  }
+
+  // deploy hyp erc20 (implementation)
+  const hypErc20Addr = await expectNextContractAddr(query, account);
+  console.log(`Deploying HypERC20 at "${hypErc20Addr.green}"...`);
+
+  {
+    const tx = await exec.deployContract({
+      abi: HypERC20__factory.abi,
+      bytecode: HypERC20__factory.bytecode,
+      args: [6, evmNetwork.mailbox_address],
     });
+    logTx('Deploying HypERC20', tx);
+    await query.waitForTransactionReceipt({ hash: tx });
+  }
 
-    if (createNewIsm && warpIsmAddress !== undefined) {
-      throw new Error("invalid options: cannot create a new ISM and pass a custom ISM address at the same time")
-    }
-  
-    // deploy hyp erc20 (implementation)
-    const hypErc20Addr = await expectNextContractAddr(query, account);
-    console.log(`Deploying HypERC20 at "${hypErc20Addr.green}"...`);
-  
-    {
-      const tx = await exec.deployContract({
-        abi: HypERC20__factory.abi,
-        bytecode: HypERC20__factory.bytecode,
-        args: [6, evmNetwork.mailbox_address],
-      });
-      logTx('Deploying HypERC20', tx);
-      await query.waitForTransactionReceipt({ hash: tx });
-    }
+  {
+    const tx = await exec.writeContract({
+      abi: HypERC20__factory.abi,
+      address: hypErc20Addr,
+      functionName: 'initialize',
+      args: [0n, contractName ? contractName : 'Hyperlane Bridged OSMO', assetName ? assetName : 'OSMO'],
+    });
+    logTx('Initialize HypERC20', tx);
+    await query.waitForTransactionReceipt({ hash: tx });
+  }
+
+  // If the option was specifed to create a new ISM, deploy the multisig ISM contract
+  if (createNewIsm) {
+    const ismValidatorAddressString = ismValidatorAddresses ? ismValidatorAddresses : account.address
+    const ismValidatorAddressesList = ismValidatorAddressString.split(",").map(address => address as `0x${string}`)
+
+    const multisigIsmAddr = await query.readContract({
+      abi: StaticMessageIdMultisigIsmFactory__factory.abi,
+      address: evmNetwork.multisig_ism_factory_address,
+      functionName: 'getAddress',
+      args: [ismValidatorAddressesList, Number(ismThreshold)],
+    });
+    console.log(`\nDeploying multisigIsm at "${multisigIsmAddr.green}"...`);
   
     {
       const tx = await exec.writeContract({
-        abi: HypERC20__factory.abi,
-        address: hypErc20Addr,
-        functionName: 'initialize',
-        args: [0n, contractName ? contractName : 'Hyperlane Bridged OSMO', assetName ? assetName : 'OSMO'],
-      });
-      logTx('Initialize HypERC20', tx);
-      await query.waitForTransactionReceipt({ hash: tx });
-    }
-  
-    // If the option was specifed to create a new ISM, deploy the multisig ISM contract
-    if (createNewIsm) {
-      ismValidatorAddress = ismValidatorAddress ? ismValidatorAddress : account.address
-  
-      const multisigIsmAddr = await query.readContract({
         abi: StaticMessageIdMultisigIsmFactory__factory.abi,
         address: evmNetwork.multisig_ism_factory_address,
-        functionName: 'getAddress',
-        args: [[ismValidatorAddress], Number(ismThreshold)],
+        functionName: 'deploy',
+        args: [ismValidatorAddressesList, Number(ismThreshold)],
       });
-      console.log(`\nDeploying multisigIsm at "${multisigIsmAddr.green}"...`);
-    
-      {
-        const tx = await exec.writeContract({
-          abi: StaticMessageIdMultisigIsmFactory__factory.abi,
-          address: evmNetwork.multisig_ism_factory_address,
-          functionName: 'deploy',
-          args: [[ismValidatorAddress], Number(ismThreshold)],
-        });
-        logTx('Deploy multisig ism', tx);
-        await query.waitForTransactionReceipt({ hash: tx });
-      }
-  
-      warpIsmAddress = multisigIsmAddr
-    }
-    
-    // If a custom ISM address was specified or if a new ISM was created,
-    // register that address in the warp contract
-    // Otherwise, the default ISM will be used
-    if (warpIsmAddress !== undefined) {
-      const tx = await exec.writeContract({
-        abi: HypERC20__factory.abi,
-        address: hypErc20Addr,
-        functionName: 'setInterchainSecurityModule',
-        args: [warpIsmAddress],
-      });
-      logTx('Set ism for warp route', tx);
+      logTx('Deploy multisig ism', tx);
       await query.waitForTransactionReceipt({ hash: tx });
     }
-    
-    console.log(`\nWarp ERC20: ${hypErc20Addr.blue}`);
-    if (warpIsmAddress !== undefined) {
-      console.log(`ISM Address: ${warpIsmAddress.blue}`);
-    }
+
+    warpIsmAddress = multisigIsmAddr
   }
   
+  // If a custom ISM address was specified or if a new ISM was created,
+  // register that address in the warp contract
+  // Otherwise, the default ISM will be used
+  if (warpIsmAddress !== undefined) {
+    const tx = await exec.writeContract({
+      abi: HypERC20__factory.abi,
+      address: hypErc20Addr,
+      functionName: 'setInterchainSecurityModule',
+      args: [warpIsmAddress],
+    });
+    logTx('Set ism for warp route', tx);
+    await query.waitForTransactionReceipt({ hash: tx });
+  }
+  
+  console.log(`\nWarp ERC20: ${hypErc20Addr.blue}`);
+  if (warpIsmAddress !== undefined) {
+    console.log(`ISM Address: ${warpIsmAddress.blue}`);
+  }
+}

--- a/script/commands/evm.ts
+++ b/script/commands/evm.ts
@@ -153,7 +153,7 @@ import {
         functionName: 'getAddress',
         args: [[ismValidatorAddress], Number(ismThreshold)],
       });
-      console.log(`Deploying multisigIsm at "${multisigIsmAddr.green}"...`);
+      console.log(`\nDeploying multisigIsm at "${multisigIsmAddr.green}"...`);
     
       {
         const tx = await exec.writeContract({
@@ -182,11 +182,10 @@ import {
       logTx('Set ism for warp route', tx);
       await query.waitForTransactionReceipt({ hash: tx });
     }
-  
-    console.log('== Done! ==');
-  
-    console.log({
-      hypErc20: hypErc20Addr,
-    });
+    
+    console.log(`\nWarp ERC20: ${hypErc20Addr.blue}`);
+    if (warpIsmAddress !== undefined) {
+      console.log(`ISM Address: ${warpIsmAddress.blue}`);
+    }
   }
   

--- a/script/commands/evm.ts
+++ b/script/commands/evm.ts
@@ -60,7 +60,7 @@ evmCmd.command('deploy-warp')
     'TIA'
   )
   .option(
-    '--warp-ism-address <warp-ism-address>', 
+    '--ism-address <warp-ism-address>', 
     'ISM to set on the warp route recipient'
   )
   .action(deployWarpRoute);
@@ -134,7 +134,7 @@ async function deployIsm({
     await query.waitForTransactionReceipt({ hash: tx });
   }
 
-  console.log(`Multisig ISM Address: ${multisigIsmAddr.blue}`);
+  console.log(`\nMultisig ISM Address: ${multisigIsmAddr.blue}`);
 }
 
 
@@ -142,14 +142,14 @@ type DeployWarpRouteArgs = {
   evmNetworkName: string,
   contractName: string,
   assetName: string,
-  warpIsmAddress?: `0x${string}`,
+  ismAddress?: `0x${string}`,
 };
 
 async function deployWarpRoute({
   evmNetworkName,
   contractName,
   assetName,
-  warpIsmAddress,
+  ismAddress,
 }: DeployWarpRouteArgs) {
   const { signer } = config;
   const evmNetwork = getEvmNetwork(evmNetworkName)
@@ -212,12 +212,12 @@ async function deployWarpRoute({
   
   // If a custom ISM address was specified, register that address in the warp contract
   // Otherwise, the default ISM will be used
-  if (warpIsmAddress !== undefined) {
+  if (ismAddress !== undefined) {
     const tx = await exec.writeContract({
       abi: HypERC20__factory.abi,
       address: hypErc20Addr,
       functionName: 'setInterchainSecurityModule',
-      args: [warpIsmAddress],
+      args: [ismAddress],
     });
     logTx('Set ism for warp route', tx);
     await query.waitForTransactionReceipt({ hash: tx });

--- a/script/commands/evm.ts
+++ b/script/commands/evm.ts
@@ -52,6 +52,11 @@ import {
       '--ism-validator-address <ism-validator-address>', 
       'Validator address on the ism',
     )
+    .option(
+      '--ism-threshold <ism-threshold>', 
+      'Threshold for the number of validators in the ISM',
+      "1",
+    )
     .action(deployWarpRoute);
   
   export { evmCmd };
@@ -63,6 +68,7 @@ import {
     createNewIsm?: boolean,
     warpIsmAddress?: `0x${string}`,
     ismValidatorAddress?: `0x${string}`,
+    ismThreshold?: number,
   };
   
   async function deployWarpRoute({
@@ -72,6 +78,7 @@ import {
     createNewIsm,
     warpIsmAddress,
     ismValidatorAddress,
+    ismThreshold,
   }: DeployWarpRouteArgs) {
     const { signer } = config;
     const evmNetwork = getEvmNetwork(evmNetworkName)
@@ -144,7 +151,7 @@ import {
         abi: StaticMessageIdMultisigIsmFactory__factory.abi,
         address: evmNetwork.multisig_ism_factory_address,
         functionName: 'getAddress',
-        args: [[ismValidatorAddress], 1],
+        args: [[ismValidatorAddress], Number(ismThreshold)],
       });
       console.log(`Deploying multisigIsm at "${multisigIsmAddr.green}"...`);
     
@@ -153,7 +160,7 @@ import {
           abi: StaticMessageIdMultisigIsmFactory__factory.abi,
           address: evmNetwork.multisig_ism_factory_address,
           functionName: 'deploy',
-          args: [[ismValidatorAddress], 1],
+          args: [[ismValidatorAddress], Number(ismThreshold)],
         });
         logTx('Deploy multisig ism', tx);
         await query.waitForTransactionReceipt({ hash: tx });

--- a/script/commands/evm.ts
+++ b/script/commands/evm.ts
@@ -1,0 +1,193 @@
+import { 
+    HypERC20__factory, 
+    StaticMessageIdMultisigIsmFactory__factory,
+  } from '@hyperlane-xyz/core';
+  import { Command, Option} from 'commander';
+  import { isAddress } from 'viem';
+  
+  import { HYP_MAILBOX, HYP_MULTSIG_ISM_FACTORY } from './constants';
+  import { CONTAINER, Dependencies } from './ioc';
+  import {
+    expectNextContractAddr,
+    extractByte32AddrFromBech32,
+    logTx,
+  } from './utils';
+  
+  const warpCmd = new Command('warp');
+  
+  warpCmd.command('deploy')
+    .option(
+      '--contract-name <contract-name>', 
+      'Warp contract name e.g. Hyperlane Bridged TIA',
+      'Hyperlane Bridged Osmo'
+    )
+    .option(
+      '--asset-name <asset-name>', 
+      'Warp route asset name e.g. TIA',
+      'TIA'
+    )
+    .option(
+      '--create-new-ism', 
+      'Option to create a new ISM for the the warp route',
+      false
+    )
+    .option(
+      '--warp-ism-address <warp-ism-address>', 
+      'ISM to set on the warp route recipient'
+    )
+    .option(
+      '--ism-validator-address <ism-validator-address>', 
+      'Validator address on the ism',
+    )
+    .action(deployWarpRoute);
+  
+  warpCmd
+    .command('link')
+    .argument('<warp>', 'address of warp route')
+    .argument('<domain>', 'destination domain to set')
+    .argument('<route>', 'destination address to set')
+    .action(linkWarpRoute);
+  
+  warpCmd
+    .command('transfer')
+    .argument('<warp>', 'address of warp route')
+    .argument('<domain>', 'destination domain to transfer')
+    .argument('<to>', 'address to transfer')
+    .action(transferWarpRoute);
+  
+  export { warpCmd };
+  
+  type DeployWarpRouteArgs = {
+    contractName: string,
+    assetName: string,
+    createNewIsm?: boolean,
+    warpIsmAddress?: `0x${string}`,
+    ismValidatorAddress?: `0x${string}`,
+  };
+  
+  async function deployWarpRoute({
+    contractName,
+    assetName,
+    createNewIsm,
+    warpIsmAddress,
+    ismValidatorAddress,
+  }: DeployWarpRouteArgs) {
+    const {
+      account,
+      provider: { query, exec },
+    } = CONTAINER.get(Dependencies);
+  
+    if (createNewIsm && warpIsmAddress !== undefined) {
+      throw new Error("invalid options: cannot create a new ISM and pass a custom ISM address at the same time")
+    }
+  
+    // deploy hyp erc20 (implementation)
+    const hypErc20Addr = await expectNextContractAddr(query, account);
+    console.log(`Deploying HypERC20 at "${hypErc20Addr.green}"...`);
+  
+    {
+      const tx = await exec.deployContract({
+        abi: HypERC20__factory.abi,
+        bytecode: HypERC20__factory.bytecode,
+        args: [6, HYP_MAILBOX],
+      });
+      logTx('Deploying HypERC20', tx);
+      await query.waitForTransactionReceipt({ hash: tx });
+    }
+  
+    {
+      const tx = await exec.writeContract({
+        abi: HypERC20__factory.abi,
+        address: hypErc20Addr,
+        functionName: 'initialize',
+        args: [0n, contractName ? contractName : 'Hyperlane Bridged OSMO', assetName ? assetName : 'OSMO'],
+      });
+      logTx('Initialize HypERC20', tx);
+      await query.waitForTransactionReceipt({ hash: tx });
+    }
+  
+    // If the option was specifed to create a new ISM, deploy the multisig ISM contract
+    if (createNewIsm) {
+      ismValidatorAddress = ismValidatorAddress ? ismValidatorAddress : account.address
+  
+      const multisigIsmAddr = await query.readContract({
+        abi: StaticMessageIdMultisigIsmFactory__factory.abi,
+        address: HYP_MULTSIG_ISM_FACTORY,
+        functionName: 'getAddress',
+        args: [[ismValidatorAddress], 1],
+      });
+      console.log(`Deploying multisigIsm at "${multisigIsmAddr.green}"...`);
+    
+      {
+        const tx = await exec.writeContract({
+          abi: StaticMessageIdMultisigIsmFactory__factory.abi,
+          address: HYP_MULTSIG_ISM_FACTORY,
+          functionName: 'deploy',
+          args: [[ismValidatorAddress], 1],
+        });
+        logTx('Deploy multisig ism', tx);
+        await query.waitForTransactionReceipt({ hash: tx });
+      }
+  
+      warpIsmAddress = multisigIsmAddr
+    }
+    
+    // If a custom ISM address was specified or if a new ISM was created,
+    // register that address in the warp contract
+    // Otherwise, the default ISM will be used
+    if (warpIsmAddress !== undefined) {
+      const tx = await exec.writeContract({
+        abi: HypERC20__factory.abi,
+        address: hypErc20Addr,
+        functionName: 'setInterchainSecurityModule',
+        args: [warpIsmAddress],
+      });
+      logTx('Set ism for warp route', tx);
+      await query.waitForTransactionReceipt({ hash: tx });
+    }
+  
+    console.log('== Done! ==');
+  
+    console.log({
+      hypErc20: hypErc20Addr,
+    });
+  }
+  
+  async function linkWarpRoute(warp: string, domain: string, route: string) {
+    const {
+      provider: { exec, query },
+    } = CONTAINER.get(Dependencies);
+  
+    if (!isAddress(warp)) throw new Error('Invalid warp address');
+  
+    const tx = await exec.writeContract({
+      abi: HypERC20__factory.abi,
+      address: warp,
+      functionName: 'enrollRemoteRouter',
+      args: [parseInt(domain), `0x${extractByte32AddrFromBech32(route)}`],
+    });
+    logTx(`Linking warp route with external chain ${domain}`, tx);
+    await query.waitForTransactionReceipt({ hash: tx });
+  }
+  
+  async function transferWarpRoute(warp: string, domain: string, to: string) {
+    const {
+      provider: { exec, query },
+    } = CONTAINER.get(Dependencies);
+  
+    if (!isAddress(warp)) throw new Error('Invalid warp address');
+  
+    const tx = await exec.writeContract({
+      abi: HypERC20__factory.abi,
+      address: warp,
+      functionName: 'transferRemote',
+      args: [
+        parseInt(domain),
+        `0x${extractByte32AddrFromBech32(to)}`,
+        1_000_000n,
+      ],
+    });
+    logTx(`Transferring warp route with external chain ${domain}`, tx);
+    await query.waitForTransactionReceipt({ hash: tx });
+  }
+  

--- a/script/commands/index.ts
+++ b/script/commands/index.ts
@@ -5,3 +5,4 @@ export { migrateCmd } from './migrate';
 export { uploadCmd } from './upload';
 export { walletCmd } from './wallet';
 export { warpCmd } from './warp';
+export { evmCmd } from './evm';

--- a/script/commands/register.ts
+++ b/script/commands/register.ts
@@ -1,0 +1,155 @@
+import { Command } from 'commander';
+
+import { IgpHookType, config } from '../shared/config';
+import { typed, ContextHook } from '../shared/context';
+import { executeMultiMsg } from '../shared/contract';
+import { CONTAINER, Dependencies } from '../shared/ioc';
+
+export const registerCmd = new Command('register')
+  .description('Register new chain to contracts')
+  .configureHelp({ showGlobalOptions: true });
+
+registerCmd.command('igporacle')
+  .action(handleRegisterIgpOracle);
+registerCmd.command('ism-multisig')
+  .action(handleRegisterIsm);
+
+type AggregateHook = (typed<'hpl_hook_aggregate'> & {
+hooks: ContextHook[];
+})
+
+type IgpHook = (typed<'hpl_igp'> & { oracle: typed<'hpl_igp_oracle'> });
+
+function isIgpHookType(hook: ContextHook): hook is IgpHook {
+    return hook.type === 'hpl_igp';
+};
+
+function findIsmsConfig() {
+    return config.deploy.ism
+};
+
+function findIgpHookInAggregate() {
+    const defaultHook = config.deploy.hooks?.default;
+    if (defaultHook && defaultHook.type === 'aggregate') {
+        const igpHook = defaultHook.hooks.find((hook): hook is IgpHookType => hook.type === 'igp');
+        return igpHook;
+    }
+    return undefined;
+};
+
+async function handleRegisterIsm(_: object, cmd: Command) {
+    const { ctx, client } = CONTAINER.get(Dependencies);
+
+    const ismMultisig = ctx.deployments.isms;
+    let ismMultisigAddress: string | undefined;
+    if (ismMultisig && ismMultisig.type === 'hpl_ism_multisig') {
+        ismMultisigAddress = ismMultisig.address
+    }
+    if (!ismMultisigAddress) {
+        throw new Error("Ism multisig context not found");
+    }
+    const ismsConfig = findIsmsConfig();
+    if (!ismsConfig) {
+        throw new Error ("Ism multisig config not found")
+    }
+    switch (ismsConfig.type) {
+        // deploy multisig ism
+        case 'multisig': {
+            const multisig = {
+                type: 'hpl_ism_multisig',
+                address: ismMultisigAddress as string
+            };
+            await executeMultiMsg(
+                client,
+                Object.entries(ismsConfig.validators).map(
+                  ([domain, { addrs, threshold }]) => ({
+                    contract: multisig,
+                    msg: {
+                      set_validators: {
+                        domain: Number(domain),
+                        threshold,
+                        validators: addrs.map((v) =>
+                          v === '<signer>' ? client.signer_addr : v,
+                        ),
+                      },
+                    },
+                  }),
+                ),
+              );
+        }
+
+        default: {
+            throw new Error('Multisig ism config not found')
+        }
+    };
+};
+
+async function handleRegisterIgpOracle(_: object, cmd: Command) {
+    const { ctx } = CONTAINER.get(Dependencies);
+
+
+    const defaultHook = ctx.deployments.hooks?.default;
+    let igpHook;
+    let aggregateHook;
+    let igpOracleAddress: string | undefined;
+    if (defaultHook && defaultHook.type === 'hpl_hook_aggregate') {
+        igpHook = defaultHook.hooks.find(isIgpHookType) as IgpHook;
+        igpOracleAddress = igpHook ? igpHook.oracle?.address : undefined;
+        aggregateHook = defaultHook as AggregateHook;
+    }
+    if (!igpHook) {
+        throw new Error('igpHook is undefined in context');
+    }
+    if (!igpOracleAddress) {
+        throw new Error('igpOracleAddress is undefined in context');
+    }
+    if (!aggregateHook) {
+        throw new Error('aggregateHook is undefined in context');
+    }
+
+    const igpType: IgpHook | undefined = aggregateHook?.hooks.find(
+        (hook): hook is IgpHook => hook.type === 'hpl_igp');
+
+    // Ensure igpType is defined
+    if (!igpType) {
+        throw new Error('igpType is undefined');
+    }
+
+    const igpHookConfig = findIgpHookInAggregate();
+    if (!igpHookConfig) {
+        throw new Error('No IGP hook found in aggregate');
+    }
+    await executeMultiMsg(client, [
+        {
+            contract: {
+                type: "hpl_igp",
+                address: igpOracleAddress
+            },
+            msg: {
+                set_remote_gas_data_configs: {
+                configs: Object.entries(igpHookConfig.configs).map(([domain, v]) => ({
+                    remote_domain: Number(domain),
+                    token_exchange_rate: v.exchange_rate.toString(),
+                    gas_price: v.gas_price.toString(),
+                })),
+                },
+            },
+            },
+            {
+            contract: {
+                type: "hpl_igp",
+                address: igpHook.address,
+            },
+            msg: {
+                router: {
+                set_routes: {
+                    set: Object.keys(igpHookConfig.configs).map((domain) => ({
+                    domain: Number(domain),
+                    route: igpOracleAddress,
+                    })),
+                },
+                },
+            },
+        },
+    ]);
+};

--- a/script/commands/register.ts
+++ b/script/commands/register.ts
@@ -9,147 +9,141 @@ export const registerCmd = new Command('register')
   .description('Register new chain to contracts')
   .configureHelp({ showGlobalOptions: true });
 
-registerCmd.command('igporacle')
-  .action(handleRegisterIgpOracle);
-registerCmd.command('ism-multisig')
-  .action(handleRegisterIsm);
+registerCmd.command('igporacle').action(handleRegisterIgpOracle);
+registerCmd.command('ism-multisig').action(handleRegisterIsm);
 
-type AggregateHook = (typed<'hpl_hook_aggregate'> & {
-hooks: ContextHook[];
-})
+type AggregateHook = typed<'hpl_hook_aggregate'> & {
+  hooks: ContextHook[];
+};
 
-type IgpHook = (typed<'hpl_igp'> & { oracle: typed<'hpl_igp_oracle'> });
+type IgpHook = typed<'hpl_igp'> & { oracle: typed<'hpl_igp_oracle'> };
 
 function isIgpHookType(hook: ContextHook): hook is IgpHook {
-    return hook.type === 'hpl_igp';
-};
+  return hook.type === 'hpl_igp';
+}
 
 function findIsmsConfig() {
-    return config.deploy.ism
-};
+  return config.deploy.ism;
+}
 
 function findIgpHookInAggregate() {
-    const defaultHook = config.deploy.hooks?.default;
-    if (defaultHook && defaultHook.type === 'aggregate') {
-        const igpHook = defaultHook.hooks.find((hook): hook is IgpHookType => hook.type === 'igp');
-        return igpHook;
-    }
-    return undefined;
-};
+  const defaultHook = config.deploy.hooks?.default;
+  if (defaultHook && defaultHook.type === 'aggregate') {
+    const igpHook = defaultHook.hooks.find(
+      (hook): hook is IgpHookType => hook.type === 'igp'
+    );
+    return igpHook;
+  }
+  return undefined;
+}
 
 async function handleRegisterIsm(_: object, cmd: Command) {
-    const { ctx, client } = CONTAINER.get(Dependencies);
+  const { ctx, client } = CONTAINER.get(Dependencies);
 
-    const ismMultisig = ctx.deployments.isms;
-    let ismMultisigAddress: string | undefined;
-    if (ismMultisig && ismMultisig.type === 'hpl_ism_multisig') {
-        ismMultisigAddress = ismMultisig.address
+  const ismMultisig = ctx.deployments.isms;
+  let ismMultisigAddress: string | undefined;
+  if (ismMultisig && ismMultisig.type === 'hpl_ism_multisig') {
+    ismMultisigAddress = ismMultisig.address;
+  }
+  if (!ismMultisigAddress) {
+    throw new Error('Ism multisig context not found');
+  }
+  const ismsConfig = findIsmsConfig();
+  if (!ismsConfig) {
+    throw new Error('Ism multisig config not found');
+  }
+  switch (ismsConfig.type) {
+    case 'multisig': {
+      const multisig = {
+        type: 'hpl_ism_multisig',
+        address: ismMultisigAddress as string,
+      };
+      await executeMultiMsg(
+        client,
+        Object.entries(ismsConfig.validators).map(([domain, { addrs, threshold }]) => ({
+          contract: multisig,
+          msg: {
+            set_validators: {
+              domain: Number(domain),
+              threshold,
+              validators: addrs.map((v) =>
+                v === '<signer>' ? client.signer_addr : v
+              ),
+            },
+          },
+        }))
+      );
+      break;
     }
-    if (!ismMultisigAddress) {
-        throw new Error("Ism multisig context not found");
-    }
-    const ismsConfig = findIsmsConfig();
-    if (!ismsConfig) {
-        throw new Error ("Ism multisig config not found")
-    }
-    switch (ismsConfig.type) {
-        // deploy multisig ism
-        case 'multisig': {
-            const multisig = {
-                type: 'hpl_ism_multisig',
-                address: ismMultisigAddress as string
-            };
-            await executeMultiMsg(
-                client,
-                Object.entries(ismsConfig.validators).map(
-                  ([domain, { addrs, threshold }]) => ({
-                    contract: multisig,
-                    msg: {
-                      set_validators: {
-                        domain: Number(domain),
-                        threshold,
-                        validators: addrs.map((v) =>
-                          v === '<signer>' ? client.signer_addr : v,
-                        ),
-                      },
-                    },
-                  }),
-                ),
-              );
-        }
-
-        default: {
-            throw new Error('Multisig ism config not found')
-        }
-    };
-};
+    default:
+      throw new Error('Multisig ism config not found');
+  }
+}
 
 async function handleRegisterIgpOracle(_: object, cmd: Command) {
-    const { ctx } = CONTAINER.get(Dependencies);
+  const { ctx, client } = CONTAINER.get(Dependencies);
 
+  const defaultHook = ctx.deployments.hooks?.default;
+  let igpHook;
+  let aggregateHook;
+  let igpOracleAddress: string | undefined;
+  if (defaultHook && defaultHook.type === 'hpl_hook_aggregate') {
+    igpHook = defaultHook.hooks.find(isIgpHookType) as IgpHook;
+    igpOracleAddress = igpHook?.oracle?.address;
+    aggregateHook = defaultHook as AggregateHook;
+  }
+  if (!igpHook) {
+    throw new Error('igpHook is undefined in context');
+  }
+  if (!igpOracleAddress) {
+    throw new Error('igpOracleAddress is undefined in context');
+  }
+  if (!aggregateHook) {
+    throw new Error('aggregateHook is undefined in context');
+  }
 
-    const defaultHook = ctx.deployments.hooks?.default;
-    let igpHook;
-    let aggregateHook;
-    let igpOracleAddress: string | undefined;
-    if (defaultHook && defaultHook.type === 'hpl_hook_aggregate') {
-        igpHook = defaultHook.hooks.find(isIgpHookType) as IgpHook;
-        igpOracleAddress = igpHook ? igpHook.oracle?.address : undefined;
-        aggregateHook = defaultHook as AggregateHook;
-    }
-    if (!igpHook) {
-        throw new Error('igpHook is undefined in context');
-    }
-    if (!igpOracleAddress) {
-        throw new Error('igpOracleAddress is undefined in context');
-    }
-    if (!aggregateHook) {
-        throw new Error('aggregateHook is undefined in context');
-    }
+  const igpType: IgpHook | undefined = aggregateHook?.hooks.find(
+    (hook): hook is IgpHook => hook.type === 'hpl_igp'
+  );
+  if (!igpType) {
+    throw new Error('igpType is undefined');
+  }
 
-    const igpType: IgpHook | undefined = aggregateHook?.hooks.find(
-        (hook): hook is IgpHook => hook.type === 'hpl_igp');
-
-    // Ensure igpType is defined
-    if (!igpType) {
-        throw new Error('igpType is undefined');
-    }
-
-    const igpHookConfig = findIgpHookInAggregate();
-    if (!igpHookConfig) {
-        throw new Error('No IGP hook found in aggregate');
-    }
-    await executeMultiMsg(client, [
-        {
-            contract: {
-                type: "hpl_igp",
-                address: igpOracleAddress
-            },
-            msg: {
-                set_remote_gas_data_configs: {
-                configs: Object.entries(igpHookConfig.configs).map(([domain, v]) => ({
-                    remote_domain: Number(domain),
-                    token_exchange_rate: v.exchange_rate.toString(),
-                    gas_price: v.gas_price.toString(),
-                })),
-                },
-            },
-            },
-            {
-            contract: {
-                type: "hpl_igp",
-                address: igpHook.address,
-            },
-            msg: {
-                router: {
-                set_routes: {
-                    set: Object.keys(igpHookConfig.configs).map((domain) => ({
-                    domain: Number(domain),
-                    route: igpOracleAddress,
-                    })),
-                },
-                },
-            },
+  const igpHookConfig = findIgpHookInAggregate();
+  if (!igpHookConfig) {
+    throw new Error('No IGP hook found in aggregate');
+  }
+  await executeMultiMsg(client, [
+    {
+      contract: {
+        type: 'hpl_igp_oracle',
+        address: igpOracleAddress,
+      },
+      msg: {
+        set_remote_gas_data_configs: {
+          configs: Object.entries(igpHookConfig.configs).map(([domain, v]) => ({
+            remote_domain: Number(domain),
+            token_exchange_rate: v.exchange_rate.toString(),
+            gas_price: v.gas_price.toString(),
+          })),
         },
-    ]);
-};
+      },
+    },
+    {
+      contract: {
+        type: 'hpl_igp',
+        address: igpHook.address,
+      },
+      msg: {
+        router: {
+          set_routes: {
+            set: Object.keys(igpHookConfig.configs).map((domain) => ({
+              domain: Number(domain),
+              route: igpOracleAddress,
+            })),
+          },
+        },
+      },
+    },
+  ]);
+}

--- a/script/commands/update.ts
+++ b/script/commands/update.ts
@@ -5,12 +5,13 @@ import { typed, ContextHook } from '../shared/context';
 import { executeMultiMsg } from '../shared/contract';
 import { CONTAINER, Dependencies } from '../shared/ioc';
 
-export const registerCmd = new Command('register')
-  .description('Register new chain to contracts')
-  .configureHelp({ showGlobalOptions: true });
+export const updateCmd = new Command('update')
+  .description('Register new chain to existing contracts')
+  .configureHelp({ showGlobalOptions: true })
+;
 
-registerCmd.command('igporacle').action(handleRegisterIgpOracle);
-registerCmd.command('ism-multisig').action(handleRegisterIsm);
+updateCmd.command('igp-oracle').action(handleRegisterIgpOracle);
+updateCmd.command('ism-multisig').action(handleRegisterIsm);
 
 type AggregateHook = typed<'hpl_hook_aggregate'> & {
   hooks: ContextHook[];
@@ -73,7 +74,6 @@ async function handleRegisterIsm(_: object, cmd: Command) {
           },
         }))
       );
-      break;
     }
     default:
       throw new Error('Multisig ism config not found');

--- a/script/commands/upload.ts
+++ b/script/commands/upload.ts
@@ -44,6 +44,7 @@ uploadCmd
   .description('upload artifacts from remote')
   .argument('<tag-name>', `name of release tag. min: ${REMOTE_MIN_VERSION}`)
   .option('-o --out <out dir>', 'artifact output directory', defaultTmpDir)
+  .option('--set-instantiate-admin', 'Sets instantiate permissions to be admin address only') 
   .action(handleRemote);
 
 uploadCmd
@@ -60,7 +61,7 @@ async function handleRemote(
   _: object,
   cmd: Command,
 ): Promise<void> {
-  const opts = cmd.optsWithGlobals() as { networkId: string; out: string };
+  const opts = cmd.optsWithGlobals() as { networkId: string; out: string; setInstantiateAdmin?: boolean  };
 
   if (tagName < REMOTE_MIN_VERSION)
     throw new Error(`${tagName} < ${REMOTE_MIN_VERSION}`);
@@ -79,7 +80,7 @@ async function handleRemote(
 
   console.log('Downloaded artifacts to', artifactPath.green);
 
-  return upload({ ...opts, artifacts: artifactPath });
+  return upload({ ...opts, artifacts: artifactPath, setInstantiateAdmin: opts.setInstantiateAdmin });
 }
 
 async function handleRemoteList() {

--- a/script/commands/wallet.ts
+++ b/script/commands/wallet.ts
@@ -7,6 +7,7 @@ import { Command } from 'commander';
 
 import { getKeyPair } from '../shared/crypto';
 import { CONTAINER, Dependencies } from '../shared/ioc';
+import { addPad, extractByte32AddrFromBech32 } from '../shared/utils';
 
 const walletCmd = new Command('wallet')
   .description('Wallet commands')
@@ -67,5 +68,17 @@ walletCmd
 
     console.log(account.address);
   });
+
+walletCmd
+  .command('zero-pad')
+  .argument('address', 'eth address of length 20 bytes')
+  .description('zero pads an ETH address to length 64 bytes')
+  .action((address: string) => console.log(`0x${addPad(address)}`));
+
+walletCmd
+  .command('convert-cosmos-to-eth')
+  .argument('address', 'converts a bech32 cosmos address to a 64 byte length eth address')
+  .description('zero pads an ETH address to length 64 bytes')
+  .action((address: string) => console.log(`0x${extractByte32AddrFromBech32(address)}`));
 
 export { walletCmd };

--- a/script/commands/warp.ts
+++ b/script/commands/warp.ts
@@ -98,7 +98,7 @@ function checkConfigType<
 
 async function handleCreate(configFile: string, cmd: Command) {
   type Option = {
-    ismAddress?: string;
+    ismAddress?: `0x{string}`;
   };
 
   const opts: Option = cmd.opts();

--- a/script/commands/warp.ts
+++ b/script/commands/warp.ts
@@ -218,6 +218,8 @@ async function handleTransfer(_: object, cmd: Command) {
     assetType: 'native' | 'cw20';
     assetId: string;
     targetDomain: string;
+    amount?: number;
+    denom?: string;
   };
 
   const opts: Option = cmd.optsWithGlobals();
@@ -255,9 +257,9 @@ async function handleTransfer(_: object, cmd: Command) {
       transfer_remote: {
         dest_domain: parseInt(opts.targetDomain),
         recipient: addPad(deps.client.signer_addr),
-        amount: `${1_000_000n}`,
+        amount: opts.amount ? `${opts.amount}n` : `${1_000_000n}`,
       },
     },
-    [{ amount: `${1_000_001n}`, denom: 'uosmo' }],
+    [{ amount: opts.amount ? `${opts.amount + 1}n` : `${1_000_001n}`, denom: opts.denom || 'uosmo' }],
   );
 }

--- a/script/commands/warp.ts
+++ b/script/commands/warp.ts
@@ -169,7 +169,7 @@ async function handleCreate(configFile: string, cmd: Command) {
   }
 
   if (opts.ismAddress) {
-    const ismResp = await executeContract(
+    await executeContract(
       deps.client,
       newWarp,
       {

--- a/script/commands/warp.ts
+++ b/script/commands/warp.ts
@@ -89,8 +89,14 @@ warpCmd
   )
   .addOption(
     new Option(
-      '--denom <denom>',
+      '--bridged-denom <bridged-denom>',
       'denom to transfer'
+    )
+  )
+  .addOption(
+    new Option(
+      '--fee-denom <fee-denom>',
+      'fee denom'
     )
   )
   .action(handleTransfer);
@@ -252,7 +258,8 @@ async function handleTransfer(_: object, cmd: Command) {
     assetId: string;
     targetDomain: string;
     amount?: number;
-    denom?: string;
+    bridgedDenom?: string;
+    feeDenom?: string;
   };
 
   const opts: Option = cmd.optsWithGlobals();
@@ -290,9 +297,18 @@ async function handleTransfer(_: object, cmd: Command) {
       transfer_remote: {
         dest_domain: parseInt(opts.targetDomain),
         recipient: addPad(deps.client.signer_addr),
-        amount: opts.amount ? `${opts.amount}n` : `${1_000_000n}`,
+        amount: opts.amount ? `${opts.amount}` : `${1_000_000n}`,
       },
     },
-    [{ amount: opts.amount ? `${opts.amount + 1}n` : `${1_000_001n}`, denom: opts.denom || 'uosmo' }],
+    [
+      {
+        amount: opts.amount ? `${opts.amount}` : `${1_000_000n}`,
+        denom: opts.bridgedDenom || 'uosmo' 
+      },
+      {
+        amount: `${1n}`,
+        denom: opts.feeDenom || 'uosmo' 
+      } ,
+    ],
   );
 }

--- a/script/commands/warp.ts
+++ b/script/commands/warp.ts
@@ -75,6 +75,18 @@ warpCmd
       'target domain id to link',
     ).makeOptionMandatory(),
   )
+  .addOption(
+    new Option(
+      '--amount <amount>',
+      'amount to send',
+    )
+  )
+  .addOption(
+    new Option(
+      '--denom <denom>',
+      'denom to transfer'
+    )
+  )
   .action(handleTransfer);
 
 export { warpCmd };

--- a/script/commands/warp.ts
+++ b/script/commands/warp.ts
@@ -108,12 +108,12 @@ function checkConfigType<
   return config.type === tokenType && config.mode === tokenMode;
 }
 
-async function handleCreate(configFile: string, cmd: Command) {
+async function handleCreate(configFile: string, _: object, cmd: Command) {
   type Option = {
     ismAddress?: `0x{string}`;
   };
 
-  const opts: Option = cmd.opts();
+  const opts: Option = cmd.optsWithGlobals();
   const deps = CONTAINER.get(Dependencies);
 
   const warpConfigFile = readFileSync(configFile, 'utf-8');

--- a/script/commands/warp.ts
+++ b/script/commands/warp.ts
@@ -22,7 +22,7 @@ warpCmd
   .addOption(
     new Option(
       '--ism <ism-address>',
-       'ISM to set on warp route',
+       'ISM to set on warp route (in bech32 format)',
       )
   )
   .action(handleCreate);
@@ -187,7 +187,8 @@ async function handleCreate(configFile: string, _: object, cmd: Command) {
   }
 
   if (opts.ismAddress) {
-    await executeContract(
+    console.log(`Setting ISM address to ${opts.ismAddress}`)
+    const response = await executeContract(
       deps.client,
       newWarp,
       {
@@ -198,7 +199,9 @@ async function handleCreate(configFile: string, _: object, cmd: Command) {
         }
       }
     );
-}
+    console.log(`Code: ${response.code}, Hash: ${response.hash}`);
+  }
+
   saveContext(deps.network.id, deps.ctx);
 }
 
@@ -306,9 +309,9 @@ async function handleTransfer(_: object, cmd: Command) {
         denom: opts.bridgedDenom || 'uosmo' 
       },
       {
-        amount: `${1n}`,
+        amount: `${50n}`,
         denom: opts.feeDenom || 'uosmo' 
-      } ,
+      },
     ],
   );
 }

--- a/script/deploy/igp.ts
+++ b/script/deploy/igp.ts
@@ -25,33 +25,36 @@ export const deployIgp = async (
     owner: client.signer,
   });
 
-  await executeMultiMsg(client, [
-    {
-      contract: igpOracle,
-      msg: {
-        set_remote_gas_data_configs: {
-          configs: Object.entries(igpType.configs).map(([domain, v]) => ({
-            remote_domain: Number(domain),
-            token_exchange_rate: v.exchange_rate.toString(),
-            gas_price: v.gas_price.toString(),
-          })),
-        },
-      },
-    },
-    {
-      contract: igp,
-      msg: {
-        router: {
-          set_routes: {
-            set: Object.keys(igpType.configs).map((domain) => ({
-              domain: Number(domain),
-              route: igpOracle.address,
+  if (igpType.configs != undefined) {
+    await executeMultiMsg(client, [
+      {
+        contract: igpOracle,
+        msg: {
+          set_remote_gas_data_configs: {
+            configs: Object.entries(igpType.configs).map(([domain, v]) => ({
+              remote_domain: Number(domain),
+              token_exchange_rate: v.exchange_rate.toString(),
+              gas_price: v.gas_price.toString(),
             })),
           },
         },
       },
-    },
-  ]);
+      {
+        contract: igp,
+        msg: {
+          router: {
+            set_routes: {
+              set: Object.keys(igpType.configs).map((domain) => ({
+                domain: Number(domain),
+                route: igpOracle.address,
+              })),
+            },
+          },
+        },
+      }
+    ],
+    );
+  };
 
   return { ...igp, oracle: igpOracle };
 };

--- a/script/deploy/ism.ts
+++ b/script/deploy/ism.ts
@@ -41,6 +41,7 @@ export async function deployIsm(
         owner: ism.owner === '<signer>' ? client.signer : ism.owner,
       });
 
+    if (ism.validators != undefined) {
       await executeMultiMsg(
         client,
         Object.entries(ism.validators).map(
@@ -58,6 +59,7 @@ export async function deployIsm(
           }),
         ),
       );
+    };
 
       return multisig;
     }

--- a/script/index.ts
+++ b/script/index.ts
@@ -15,7 +15,7 @@ import {
 import { config, getNetwork, getSigningClient } from './shared/config';
 import { loadContext } from './shared/context';
 import { CONTAINER, Dependencies } from './shared/ioc';
-import { registerCmd } from './commands/register';
+import { updateCmd } from './commands/update';
 
 colors.enable();
 
@@ -39,7 +39,7 @@ cli.addCommand(contextCmd);
 cli.addCommand(contractCmd);
 cli.addCommand(deployCmd);
 cli.addCommand(migrateCmd);
-cli.addCommand(registerCmd);
+cli.addCommand(updateCmd);
 cli.addCommand(uploadCmd);
 cli.addCommand(walletCmd);
 cli.addCommand(warpCmd);

--- a/script/index.ts
+++ b/script/index.ts
@@ -6,6 +6,7 @@ import { version } from '../package.json';
 import {
   contextCmd,
   contractCmd,
+  evmCmd,
   deployCmd,
   migrateCmd,
   uploadCmd,
@@ -41,6 +42,7 @@ cli.addCommand(migrateCmd);
 cli.addCommand(uploadCmd);
 cli.addCommand(walletCmd);
 cli.addCommand(warpCmd);
+cli.addCommand(evmCmd);
 
 cli.parseAsync(process.argv).catch(console.error);
 

--- a/script/index.ts
+++ b/script/index.ts
@@ -15,6 +15,7 @@ import {
 import { config, getNetwork, getSigningClient } from './shared/config';
 import { loadContext } from './shared/context';
 import { CONTAINER, Dependencies } from './shared/ioc';
+import { registerCmd } from './commands/register';
 
 colors.enable();
 
@@ -38,6 +39,7 @@ cli.addCommand(contextCmd);
 cli.addCommand(contractCmd);
 cli.addCommand(deployCmd);
 cli.addCommand(migrateCmd);
+cli.addCommand(registerCmd);
 cli.addCommand(uploadCmd);
 cli.addCommand(walletCmd);
 cli.addCommand(warpCmd);

--- a/script/shared/config.ts
+++ b/script/shared/config.ts
@@ -116,6 +116,20 @@ export type Config = {
     tm_version?: '34' | '37' | '38';
   }[];
 
+  evmNetworks: {
+    name: string;
+    chain_id: number;
+    rpc_endpoint: string;
+    network: string;
+    nativeCurrency: {
+      name: string;
+      symbol: string;
+      decimals: number;
+    };
+    mailboxAddress: `0x${string}`;
+    multisigIsmFactoryAddress: `0x${string}`;
+  }[];
+
   signer: string;
 
   deploy: {
@@ -145,6 +159,13 @@ export const getNetwork = (networkId: string): Config['networks'][number] => {
 };
 
 export const config = yaml.load(readFileSync(path, 'utf-8')) as Config;
+
+export const getEvmNetwork = (networkName: string): Config['evmNetworks'][number] => {
+  const ret = config.evmNetworks.find((v) => v.name === networkName);
+  if (!ret)
+    throw new Error(`EVM Network ${networkName} not found in the config file`);
+  return ret;
+}
 
 export async function getSigningClient(
   networkId: string,

--- a/script/shared/config.ts
+++ b/script/shared/config.ts
@@ -116,18 +116,18 @@ export type Config = {
     tm_version?: '34' | '37' | '38';
   }[];
 
-  evmNetworks: {
+  evm_networks: {
     name: string;
     chain_id: number;
     rpc_endpoint: string;
     network: string;
-    nativeCurrency: {
+    native_currency: {
       name: string;
       symbol: string;
       decimals: number;
     };
-    mailboxAddress: `0x${string}`;
-    multisigIsmFactoryAddress: `0x${string}`;
+    mailbox_address: `0x${string}`;
+    multisig_ism_factory_address: `0x${string}`;
   }[];
 
   signer: string;
@@ -160,8 +160,8 @@ export const getNetwork = (networkId: string): Config['networks'][number] => {
 
 export const config = yaml.load(readFileSync(path, 'utf-8')) as Config;
 
-export const getEvmNetwork = (networkName: string): Config['evmNetworks'][number] => {
-  const ret = config.evmNetworks.find((v) => v.name === networkName);
+export const getEvmNetwork = (networkName: string): Config['evm_networks'][number] => {
+  const ret = config.evm_networks.find((v) => v.name === networkName);
   if (!ret)
     throw new Error(`EVM Network ${networkName} not found in the config file`);
   return ret;

--- a/script/shared/context.ts
+++ b/script/shared/context.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { defaultContextPath } from './constants';
 import { ContractNames } from './contract';
 
-type typed<T extends ContractNames> = {
+export type typed<T extends ContractNames> = {
   type: T;
   address: string;
   hexed: string;


### PR DESCRIPTION
These PR contains the scripts which we used at Stride to deploy hyperlane

Modifies
* deploy test recipient command for setting a custom address for its ISM
* deploy warp route to support options for contract name, token name, whether to create a new ism, and what validators to use for its new ism
* upload command to set the admin as the uploader
* warp create command to set an ism by address
* warp transfer command to specify the amount and denom

Adds
* commands for deploying an ism and warp route on an evm network
* commands for updating the igp oracle and ism multisig based on what's in the config files
* utilities for generating a zero padded address and an eth address from a cosmos address