### PR TITLE
decrease index.chunk size from 10,000 to 5

### DIFF
--- a/script/shared/agent.ts
+++ b/script/shared/agent.ts
@@ -61,7 +61,7 @@ export async function fromContext(
                   mailboxContractInfo.contract_info.created.block_height,
                 ) - 1
               : undefined,
-          chunk: 10_000,
+          chunk: 5,
         },
         blocks: {
           confirmations: 0,


### PR DESCRIPTION
this reduces the number of concurrent rpc requests when the validator is trying to catch up from an old block

Co-authored-by: @sampocs
